### PR TITLE
修改唯一一处非使用env()函数对\mix\base\Env的绝对调用

### DIFF
--- a/src/http/Error.php
+++ b/src/http/Error.php
@@ -65,7 +65,7 @@ class Error extends Component
         // 清空系统错误
         ob_get_contents() and ob_clean();
         // 错误响应
-        if (!\mix\base\Env::get('APP_DEBUG')) {
+        if (!env('APP_DEBUG')) {
             if ($statusCode == 404) {
                 $errors = [
                     'status'  => 404,


### PR DESCRIPTION
我在本地开发过程中，需要对`\mix\base\Env`进行重载，发现框架内，除了入口处（可修改），在vendor下只有这里的绝对引用了这个`\mix\base\Env::get()`，这样我就没办法通过提前声明`env()` 函数的方法重载`\mix\base\Env::get()`的行为，因为环境变量保存在`\mix\base\Env`的静态属性里面，而不是我在入口处修改的那个新env类